### PR TITLE
fix: Snowflake pipe creation failure

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,6 +56,7 @@ jobs:
     name: Generate Changelog
     runs-on: ubuntu-latest
     needs: ci
+    if: github.ref != 'refs/heads/main'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -86,9 +87,7 @@ jobs:
   create-release:
     name: Create Release
     runs-on: ubuntu-latest
-    needs:
-      - ci
-      - generate-changelog
+    needs: ci
     if: github.ref == 'refs/heads/main'
     permissions:
       contents: write

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,14 +11,14 @@ on:
       - infra/aws/tf/**
       - infra/snowflake/tf/**
       - infra/platform/tf/**
-      - infra/input-jsons/**
+      - input-jsons/**
   pull_request:
     branches: [main]
     paths:
       - infra/aws/tf/**
       - infra/snowflake/tf/**
       - infra/platform/tf/**
-      - infra/input-jsons/**
+      - input-jsons/**
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/create-branch.yaml
+++ b/.github/workflows/create-branch.yaml
@@ -1,4 +1,4 @@
-name: Auto Create Branch on Issue Assignment
+name: Auto Create Branch
 run-name: Create Feature Branch by ${{ github.actor }} on ${{ github.ref_name }}
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,22 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Miscellaneous Tasks
+
+- **config:** Update AWS S3 bucket name for e2e testing
+- **config:** Update AWS S3 bucket name in e2e configuration
+- **config:** Update AWS S3 bucket name in configuration
+- **config:** Update S3 bucket name and CI workflow paths
+
+### Refactor
+
+- **platform:** Reorganize snowpipe creation into separate phase
+
+## [Rel-002-20260129161615] - 2026-01-29
+
 ### Documentation
 
+- Update CHANGELOG.md [skip ci]
 - Update CHANGELOG.md [skip ci]
 
 ## [Rel-001-20260129155431] - 2026-01-29

--- a/infra/platform/tf/main.tf
+++ b/infra/platform/tf/main.tf
@@ -13,7 +13,7 @@
 #                             │
 #                             ▼
 # ┌─────────────────────────────────────────────────────────────┐
-# │  PHASE 2: Snowflake Resources (module.snowflake)            │
+# │  PHASE 2: Snowflake Base Resources (module.snowflake)       │
 # ├─────────────────────────────────────────────────────────────┤
 # │  1. Warehouses (compute resources)                          │
 # │  2. Databases & Schemas                                     │
@@ -23,8 +23,7 @@
 # │                  STORAGE_AWS_EXTERNAL_ID                    │
 # │  5. External Stages (S3 paths)                              │
 # │  6. Tables (target tables for data)                         │
-# │  7. Snowpipes (auto-ingest pipelines)                       │
-# │     └─► Output: SQS Notification Channel ARN                │
+# │  NOTE: Snowpipes created separately in Phase 4              │
 # └─────────────────────────────────────────────────────────────┘
 #                             │
 #                             ▼
@@ -38,7 +37,16 @@
 #                             │
 #                             ▼
 # ┌─────────────────────────────────────────────────────────────┐
-# │  PHASE 4: S3 Event Notifications (module.s3_event_notification)│
+# │  PHASE 4: Snowpipes (snowflake_pipe resources)              │
+# ├─────────────────────────────────────────────────────────────┤
+# │  Create Snowpipes AFTER trust policy is updated             │
+# │  (auto_ingest requires valid IAM role assumption)           │
+# │     └─► Output: SQS Notification Channel ARN                │
+# └─────────────────────────────────────────────────────────────┘
+#                             │
+#                             ▼
+# ┌─────────────────────────────────────────────────────────────┐
+# │  PHASE 5: S3 Event Notifications (module.s3_event_notification)│
 # ├─────────────────────────────────────────────────────────────┤
 # │  Configure S3 bucket event notifications to trigger         │
 # │  Snowpipe auto-ingest via SQS queue                         │
@@ -66,7 +74,7 @@ module "aws" {
 }
 
 # ----------------------------------------------------------------------------
-# Phase 2: Snowflake Resources (COMMENTED OUT)
+# Phase 2: Snowflake Base Resources (WITHOUT Snowpipes)
 # ----------------------------------------------------------------------------
 module "snowflake" {
   source = "../../snowflake/tf"
@@ -79,7 +87,7 @@ module "snowflake" {
   storage_integration_config = local.storage_integrations
   stage_config               = local.stages
   table_config               = local.tables
-  snowpipe_config            = local.snowpipes
+  snowpipe_config            = {} # Empty - Snowpipes created in Phase 4
 
   depends_on = [module.aws]
 }
@@ -108,7 +116,27 @@ module "aws_iam_role_final" {
 }
 
 # ----------------------------------------------------------------------------
-# Phase 4: Configure S3 Event Notifications for Snowpipe Auto-Ingest
+# Phase 4: Snowpipes (created AFTER trust policy is updated)
+# ----------------------------------------------------------------------------
+# Snowpipes with auto_ingest=true require the IAM role to be assumable by
+# Snowflake. Creating them after the trust policy update ensures the
+# storage integration can successfully assume the IAM role.
+# ----------------------------------------------------------------------------
+resource "snowflake_pipe" "this" {
+  for_each = local.snowpipes
+
+  name           = each.value.name
+  database       = each.value.database
+  schema         = each.value.schema
+  copy_statement = each.value.copy_statement
+  auto_ingest    = lookup(each.value, "auto_ingest", true)
+  comment        = lookup(each.value, "comment", "")
+
+  depends_on = [module.aws_iam_role_final, module.snowflake]
+}
+
+# ----------------------------------------------------------------------------
+# Phase 5: Configure S3 Event Notifications for Snowpipe Auto-Ingest
 # ----------------------------------------------------------------------------
 locals {
   # Check if snowpipes are configured (known at plan time from input config)
@@ -116,7 +144,7 @@ locals {
 
   # Build notification configs from snowpipe outputs
   snowpipe_notifications = [
-    for key, pipe in module.snowflake.snowpipes : {
+    for key, pipe in snowflake_pipe.this : {
       id            = key
       sqs_arn       = pipe.notification_channel
       events        = ["s3:ObjectCreated:*"]
@@ -134,5 +162,5 @@ module "s3_event_notification" {
   bucket_name   = local.s3_config.bucket_name
   notifications = local.snowpipe_notifications
 
-  depends_on = [module.snowflake, module.aws_iam_role_final]
+  depends_on = [snowflake_pipe.this, module.aws_iam_role_final]
 }

--- a/infra/platform/tf/outputs.tf
+++ b/infra/platform/tf/outputs.tf
@@ -60,3 +60,18 @@ output "storage_aws_external_id" {
   description = "storage_aws_external_id"
   value       = local.snowflake_external_id_output
 }
+
+output "snowpipes" {
+  description = "Map of snowpipe names to their details"
+  value = {
+    for k, v in snowflake_pipe.this : k => {
+      name                 = v.name
+      database             = v.database
+      schema               = v.schema
+      copy_statement       = v.copy_statement
+      auto_ingest          = v.auto_ingest
+      notification_channel = v.notification_channel
+      comment              = v.comment
+    }
+  }
+}

--- a/input-jsons/aws/config.json
+++ b/input-jsons/aws/config.json
@@ -2,7 +2,7 @@
   "aws": {
     "region": "us-east-1",
     "s3": {
-      "bucket_name": "aws-snowflake-data",
+      "bucket_name": "aws-snowflake-bucket",
       "bucket_keys": ["raw-data/csv","raw-data/json"],
       "versioning": true,
       "kms_key_alias": "SB-KMS"

--- a/input-jsons/aws/config.json
+++ b/input-jsons/aws/config.json
@@ -2,7 +2,7 @@
   "aws": {
     "region": "us-east-1",
     "s3": {
-      "bucket_name": "aws-snowflake-bucket",
+      "bucket_name": "aws-snowflake-project",
       "bucket_keys": ["raw-data/csv","raw-data/json"],
       "versioning": true,
       "kms_key_alias": "SB-KMS"

--- a/input-jsons/aws/config.json
+++ b/input-jsons/aws/config.json
@@ -2,7 +2,7 @@
   "aws": {
     "region": "us-east-1",
     "s3": {
-      "bucket_name": "snowflake-lakehouse-1",
+      "bucket_name": "snowflake-e2e-project",
       "bucket_keys": ["raw-data/csv","raw-data/json"],
       "versioning": true,
       "kms_key_alias": "SB-KMS"

--- a/input-jsons/aws/config.json
+++ b/input-jsons/aws/config.json
@@ -2,7 +2,7 @@
   "aws": {
     "region": "us-east-1",
     "s3": {
-      "bucket_name": "snowflake-e2e-project",
+      "bucket_name": "aws-snowflake-data",
       "bucket_keys": ["raw-data/csv","raw-data/json"],
       "versioning": true,
       "kms_key_alias": "SB-KMS"


### PR DESCRIPTION
This pull request includes several infrastructure and configuration updates, focusing on improving the deployment workflow and reorganizing how Snowpipe resources are managed in Terraform. The changes also update S3 bucket names across configurations and CI workflows, and enhance output visibility for Snowpipe resources.

**Infrastructure and Terraform Refactoring:**

* Snowpipe resources are now created in a separate phase (Phase 4) after updating the IAM trust policy, ensuring that auto-ingest Snowpipes are only created once the required AWS role can be assumed by Snowflake. This includes moving their creation out of the main Snowflake module and into dedicated `snowflake_pipe` resources, and updating the S3 event notification phase accordingly. Documentation in `main.tf` has been updated to reflect this phased approach. [[1]](diffhunk://#diff-9406336fb96ef7430d7d8e76349615f6b77df0d46853f51d7ad614e5f1cc96f4L16-R16) [[2]](diffhunk://#diff-9406336fb96ef7430d7d8e76349615f6b77df0d46853f51d7ad614e5f1cc96f4L26-R26) [[3]](diffhunk://#diff-9406336fb96ef7430d7d8e76349615f6b77df0d46853f51d7ad614e5f1cc96f4L41-R49) [[4]](diffhunk://#diff-9406336fb96ef7430d7d8e76349615f6b77df0d46853f51d7ad614e5f1cc96f4L69-R77) [[5]](diffhunk://#diff-9406336fb96ef7430d7d8e76349615f6b77df0d46853f51d7ad614e5f1cc96f4L82-R90) [[6]](diffhunk://#diff-9406336fb96ef7430d7d8e76349615f6b77df0d46853f51d7ad614e5f1cc96f4L111-R147) [[7]](diffhunk://#diff-9406336fb96ef7430d7d8e76349615f6b77df0d46853f51d7ad614e5f1cc96f4L137-R165)

* The Terraform output has been enhanced to include a new `snowpipes` output, providing a map of Snowpipe resource details for downstream consumption or inspection.

**Configuration and CI/CD Workflow Updates:**

* The S3 bucket name for AWS resources has been updated in `input-jsons/aws/config.json` and referenced in the changelog. [[1]](diffhunk://#diff-3cee28e40ea1ed1359bfcc4ea734b1d38a19cafc18ceeaa53fb99f2dbdefe2daL5-R5) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R22)

* The CI workflow paths have been adjusted to reference the correct `input-jsons/` directory instead of `infra/input-jsons/`, ensuring the workflow triggers correctly on changes to configuration files.

* The "Generate Changelog" workflow now only runs on non-main branches, and the "Create Release" workflow depends solely on the CI job, not on changelog generation, streamlining the release process. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR59) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL89-R90)

**Miscellaneous:**

* The branch creation workflow has been renamed for clarity.

* The changelog has been updated to document these configuration and refactor changes.